### PR TITLE
allow build on ARM

### DIFF
--- a/switch.rb
+++ b/switch.rb
@@ -6,7 +6,6 @@ class Switch < Formula
   sha256 "93c131f9b8103604bd840d62cd2c5086be63da5454e73789e49bddf9f238088f"
 
   depends_on "danielfoehrkn/switch/switcher"
-  depends_on :arch => :x86_64
 
   def install
     prefix.install "switch.sh"

--- a/switcher.rb
+++ b/switcher.rb
@@ -16,8 +16,6 @@ class Switcher < Formula
     sha256 "c93273e3ec228e65e68a669d48ce142acd5343c326ae519a7f3e2e124dc8aecb"
   end
 
-  depends_on :arch => :x86_64
-
   def install
       if OS.mac?
         if Hardware::CPU.arm?


### PR DESCRIPTION
Fix the following error on M1 mac

```
switcher: The x86_64 architecture is required for this software.
Error: switch: Unsatisfied requirements failed this build.
```